### PR TITLE
Remove hardcoded vaUpdate dependency on networkx

### DIFF
--- a/Citation_Tree.py
+++ b/Citation_Tree.py
@@ -244,7 +244,7 @@ for bibCode_one_paper, data_one_paper in data_all_papers.items():
 df = pd.DataFrame({ 'from':from_all_papers, 'to':to_all_papers})
 
 # Build your graph
-G=nx.from_pandas_dataframe(df, 'from', 'to', create_using=nx.DiGraph())
+G=nx.from_pandas_edgelist(df, 'from', 'to', create_using=nx.DiGraph())
 
 # determine vertices' coordinate
 if not nx.is_directed_acyclic_graph(G):


### PR DESCRIPTION
Hi,

I like your project but thought it could use some upgrades! This PR probably also needs a README update, but that can easily be arranged. Let me know what you find of my changes :)

This PR contains the following modifications/additions:
* Update code to be compatible with `networkx` 2.x
* Support for different webdrivers (Chrome, Gecko, PhantomJS)
* CLI options instead of hardcoded variables
* Support for headless mode
* Print a message when a paper is ignored due to missing `arxivId`
* Support for non-standard BibTex entries. Entries like `@online` will probably be ignored due to them likely having no `arxivId` anyways, but it a) removes bibtexparser warnings and b) doesn't hurt either. If they do have an `arxivId`, it's probably expected behaviour that they're also considered.
* Fixed a spelling mistake